### PR TITLE
Update @types/mongodb's semver

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@types/jest": "^23.3.2",
-    "@types/mongodb": "^3.4.1",
+    "@types/mongodb": "^3.3.14",
     "@types/node": "^13.1.1",
     "jest": "^24.9.0",
     "ts-jest": "^24.2.0",


### PR DESCRIPTION
It seems `package.json` was pointing to a non-existing version of `@types/mongodb`. When running `npm install` one would get the following output:

![npm install](https://user-images.githubusercontent.com/20454870/72993470-1914c300-3dfe-11ea-8bf1-4e959c85c85c.png)

I chose the latest version as of now from npm:

![version](https://user-images.githubusercontent.com/20454870/72993617-5a0cd780-3dfe-11ea-9626-732b5e0cf462.png)