### PR TITLE
Fix: populateMany should take into account array refs

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   },
   "devDependencies": {
     "@types/jest": "^28.1.6",
-    "@types/mongodb": "^4.0.7",
     "@types/node": "^18.0.6",
     "jest": "^28.1.3",
     "ts-jest": "^28.0.7",


### PR DESCRIPTION
This pull request comes with:

- Fix to the `populateMany`, where it should take into account array `@ref`s
- Optimization of its logic
- Appropriate unit tests for that case
- Missing docs in the readme
- Removal of `@types/mongodb` which is obsolete